### PR TITLE
path check

### DIFF
--- a/src/Middleware/RedirectHandlerAction.php
+++ b/src/Middleware/RedirectHandlerAction.php
@@ -20,7 +20,6 @@
 namespace ExpressiveRedirectHandler\Middleware;
 
 use InvalidArgumentException;
-use RuntimeException;
 use Zend\Diactoros\Response\RedirectResponse;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Diactoros\Uri;
@@ -61,8 +60,8 @@ class RedirectHandlerAction
 
             if ($match->isFailure()) {
                 throw new InvalidArgumentException(sprintf(
-                        'default_url "%s" is not match with any registered routes',
-                        $default_url
+                    'default_url "%s" is not match with any registered routes',
+                    $default_url
                 ));
             }
 
@@ -76,9 +75,6 @@ class RedirectHandlerAction
             ) {
                 return $response->withHeader('location', $default_url);
             } else {
-                if ($currentPath === $uriTargetPath) {
-                    throw new RuntimeException('Current path with target uri should not be same');
-                }
                 if ($currentPath !== $uriTargetPath) {
                     return $response;
                 }

--- a/src/Middleware/RedirectHandlerAction.php
+++ b/src/Middleware/RedirectHandlerAction.php
@@ -45,24 +45,29 @@ class RedirectHandlerAction
 
         if ($response instanceof RedirectResponse) {
             $allow_not_routed_url = (isset($this->config['allow_not_routed_url'])) ? $this->config['allow_not_routed_url'] : false;
-            $default_url = (isset($this->config['default_url'])) ? $this->config['default_url'] : '/';
+            $default_url          = (isset($this->config['default_url'])) ? $this->config['default_url'] : '/';
 
             if (true === $allow_not_routed_url) {
                 return $response;
             }
 
             $currentPath = $request->getUri()->getPath();
-            $uri     = $response->getHeader('location')[0];
-            $request = $request->withUri(new Uri($uri));
-            $match   = $this->router->match($request);
+            $uriTarget   = $response->getHeader('location')[0];
+
+            $request       = $request->withUri(new Uri($uriTarget));
+            $uriTargetPath = $request->getUri()->getPath();
+            $match         = $this->router->match($request);
 
             if ($match->isFailure()
-                &&  $uri !==  $default_url
+                && $uriTarget !==  $default_url
+                && $uriTargetPath !== $default_url
                 && $currentPath !== $default_url
             ) {
                 return $response->withHeader('location', $default_url);
             } else {
-                if ($uri !== $currentPath) {
+                if ($uriTargetPath !== $currentPath
+                    || $uriTarget !== $currentPath
+                ) {
                     return $response;
                 }
             }

--- a/src/Middleware/RedirectHandlerAction.php
+++ b/src/Middleware/RedirectHandlerAction.php
@@ -55,18 +55,9 @@ class RedirectHandlerAction
             $currentPath = $request->getUri()->getPath();
             $uriTarget   = $response->getHeader('location')[0];
 
-            $request       = $request->withUri(new Uri($default_url));
-            $match         = $this->router->match($request);
-
-            if ($match->isFailure()) {
-                throw new InvalidArgumentException(sprintf(
-                    'default_url "%s" is not match with any registered routes',
-                    $default_url
-                ));
-            }
-
+            $newUri        = new Uri($uriTarget);
             $request       = $request->withUri(new Uri($uriTarget));
-            $uriTargetPath = $request->getUri()->getPath();
+            $uriTargetPath = $newUri->getPath();
             $match         = $this->router->match($request);
 
             if ($match->isFailure()

--- a/test/Middleware/RedirectHandlerActionTest.php
+++ b/test/Middleware/RedirectHandlerActionTest.php
@@ -49,7 +49,7 @@ class RedirectHandlerActionTest extends \PHPUnit_Framework_TestCase
             $config,
             $this->router->reveal()
         );
-    } 
+    }
 
     public function provideNextForInvokeWithResponse()
     {
@@ -104,8 +104,6 @@ class RedirectHandlerActionTest extends \PHPUnit_Framework_TestCase
 
     public function testInvokeRedirectResponseToSameUri()
     {
-        $this->setExpectedException('RuntimeException');
-
         $request  = $this->prophesize(ServerRequest::class);
         $response = new RedirectResponse('/');
         $next = function ($req, $res, $err = null) use ($response) {


### PR DESCRIPTION
use case: 
when current path = '/foo' and uri target = '/foo?somequery' , it was make it still not infinite redirect, it fixed now.
